### PR TITLE
Add commands to open/copy file/selection as playground URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ## Features
 
-Adds a link to JavaScript and TypeScript codeblocks in markdown to open in the TypeScript playground.
+- Adds a link to JavaScript and TypeScript codeblocks in markdown to open in the TypeScript playground.
 
 ![screenshots/vscode-open-in-playground.gif](screenshots/vscode-open-in-playground.gif)
 
+- Adds a command to open the file or selection in the TypeScript playground
 - Very few dependencies
 - Is very memory efficient

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:markdown"
+    "onLanguage:markdown",
+    "onCommand:tsPlayground.openFileAsPlayground",
+    "onCommand:tsPlayground.copyFileAsPlaygroundURL",
+    "onCommand:tsPlayground.openSelectionInPlayground",
+    "onCommand:tsPlayground.copySelectionAsPlaygroundURL"
   ],
   "main": "./out/extension.js",
   "scripts": {
@@ -39,5 +43,49 @@
   },
   "dependencies": {
     "gfm-code-blocks": "^1.0.0"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "tsPlayground.openFileInPlayground",
+        "category": "TypeScript Playground",
+        "title": "Open File in Playground"
+      },
+      {
+        "command": "tsPlayground.copyFileAsPlaygroundURL",
+        "category": "TypeScript Playground",
+        "title": "Copy File as Playground URL"
+      },
+      {
+        "command": "tsPlayground.openSelectionInPlayground",
+        "category": "TypeScript Playground",
+        "title": "Open Selection in Playground"
+      },
+      {
+        "command": "tsPlayground.copySelectionAsPlaygroundURL",
+        "category": "TypeScript Playground",
+        "title": "Copy Selection as Playground URL"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "tsPlayground.openFileInPlayground",
+          "when": "editorLangId == 'typescript' && !editorHasSelection"
+        },
+        {
+          "command": "tsPlayground.copyFileAsPlaygroundURL",
+          "when": "editorLangId == 'typescript' && !editorHasSelection"
+        },
+        {
+          "command": "tsPlayground.openSelectionInPlayground",
+          "when": "editorLangId == 'typescript' && editorHasSelection"
+        },
+        {
+          "command": "tsPlayground.copySelectionAsPlaygroundURL",
+          "when": "editorLangId == 'typescript' && editorHasSelection"
+        }
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-ts-markdown-to-playground",
   "publisher": "Orta",
-  "displayName": "Codeblocks to TS Playground",
-  "description": "Make markdown codeblocks link to the TypeScript playground ",
+  "displayName": "Open in TypeScript Playground",
+  "description": "Open TypeScript code in the TypeScript Playground",
   "version": "1.0.2",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -71,19 +71,19 @@
       "commandPalette": [
         {
           "command": "tsPlayground.openFileInPlayground",
-          "when": "editorLangId == 'typescript' && !editorHasSelection"
+          "when": "editorLangId =~ /typescript(react)?/ && !editorHasSelection"
         },
         {
           "command": "tsPlayground.copyFileAsPlaygroundURL",
-          "when": "editorLangId == 'typescript' && !editorHasSelection"
+          "when": "editorLangId =~ /typescript(react)?/ && !editorHasSelection"
         },
         {
           "command": "tsPlayground.openSelectionInPlayground",
-          "when": "editorLangId == 'typescript' && editorHasSelection"
+          "when": "editorLangId =~ /typescript(react)?/ && editorHasSelection"
         },
         {
           "command": "tsPlayground.copySelectionAsPlaygroundURL",
-          "when": "editorLangId == 'typescript' && editorHasSelection"
+          "when": "editorLangId =~ /typescript(react)?/ && editorHasSelection"
         }
       ]
     }


### PR DESCRIPTION
Adds commands inside TypeScript files to open current file or current selection in playground (depending on whether there’s a selection), or to copy the playground URL to the clipboard.

<details>
<summary>Even works with multiple cursors 🙃 </summary>

![Kapture 2019-07-27 at 23 28 21](https://user-images.githubusercontent.com/3277153/62003103-4fc78600-b0c6-11e9-917f-c5137c80b0f7.gif)
</details>

<details>
<summary>And trims leading whitespace:</summary>

![Kapture 2019-07-27 at 23 30 02](https://user-images.githubusercontent.com/3277153/62003112-8d2c1380-b0c6-11e9-8c2d-4d46f2ec2190.gif)
</details>

I updated the title/description too since it’s no longer just markdown / code fences, but feel free to change it however (add suggestions and I’ll commit)